### PR TITLE
Add --prefix option in arcus_cmd.py to dump prefix stats

### DIFF
--- a/arcus_cmd.py
+++ b/arcus_cmd.py
@@ -383,7 +383,7 @@ if __name__ == '__main__':
 			result = ""
 			printed_count = 0
 			for current_prefix, prefix_stats in stats.items():
-				if current_prefix.startswith(prefix) or prefix == '*':
+				if prefix == 'all' or current_prefix.startswith(prefix) or (current_prefix=='<null>' and prefix=='null'):
 					printed_count += 1
 					heading = "PREFIX %-10s " % (current_prefix)
 					result += heading


### PR DESCRIPTION
`arcus_cmd.py`에 prefix 통계를 요약해서 보여주는 옵션 `-p` `--prefix`를 추가했습니다.

`-p` 옵션에 prefix name을 인자로 주게 되면 각 arcus-memcached 노드에 `stats prefixes`와 `stats detail dump` 명령을 보내 결과를 파싱하고 요약하여 stdout으로 보여줍니다.

아래와 같이 저장 공간 통계와 수행 연산 통계가 각 노드 마다 출력되고, 총 합도 출력됩니다.

```
$ python3 arcus_cmd.py -a localhost:2181 -s test -p arcus

## Zookeeper address localhost:2181
[127.0.0.1:11211-(localhost)]
[127.0.0.1:11212-(localhost)]
[127.0.0.1:11211-(localhost)]
PREFIX arcus      itm       1 kitm       1 litm       0 sitm       0 bitm       0
                  tsz      80 ktsz      80 ltsz       0 stsz       0 btsz       0 time 20160609082004

PREFIX arcus      get       0 hit       0 set      14 del       0
                  lcs       0 lis       0 lih       0 lds       0 ldh       0 lgs       0 lgh       0
                  scs       0 sis       0 sih       0 sds       0 sdh       0 sgs       0 sgh       0 ses       0 seh       0
                  bcs       0 bis       0 bih       0 bus       0 buh       0 bds       0 bdh       0
                              bps       0 bph       0 bms       0 bmh       0 bgs       0 bgh       0 bns       0 bnh       0
                              pfs       0 pfh       0 pgs       0 pgh       0
                  gps       0 gph       0 gas       0 sas       0

[127.0.0.1:11212-(localhost)]
PREFIX arcus      itm       1 kitm       1 litm       0 sitm       0 bitm       0
                  tsz      80 ktsz      80 ltsz       0 stsz       0 btsz       0 time 20160609082004

PREFIX arcus      get       0 hit       0 set    1118 del       0
                  lcs       0 lis       0 lih       0 lds       0 ldh       0 lgs       0 lgh       0
                  scs       0 sis       0 sih       0 sds       0 sdh       0 sgs       0 sgh       0 ses       0 seh       0
                  bcs       0 bis       0 bih       0 bus       0 buh       0 bds       0 bdh       0
                              bps       0 bph       0 bms       0 bmh       0 bgs       0 bgh       0 bns       0 bnh       0
                              pfs       0 pfh       0 pgs       0 pgh       0
                  gps       0 gph       0 gas       0 sas       0

[Total]
PREFIX arcus      itm       2 kitm       2 litm       0 sitm       0 bitm       0
                  tsz     160 ktsz     160 ltsz       0 stsz       0 btsz       0

PREFIX arcus      get       0 hit       0 set    1132 del       0
                  lcs       0 lis       0 lih       0 lds       0 ldh       0 lgs       0 lgh       0
                  scs       0 sis       0 sih       0 sds       0 sdh       0 sgs       0 sgh       0 ses       0 seh       0
                  bcs       0 bis       0 bih       0 bus       0 buh       0 bds       0 bdh       0
                              bps       0 bph       0 bms       0 bmh       0 bgs       0 bgh       0 bns       0 bnh       0
                              pfs       0 pfh       0 pgs       0 pgh       0
                  gps       0 gph       0 gas       0 sas       0
```

결과가 없는 경우에는 결과가 없다고 나옵니다. 아래는 한 노드에 `stats detail off`를 하고 결과를 가져와 본 결과입니다.

```
$ python3 arcus_cmd.py -a localhost:2181 -s test -p test


## Zookeeper address localhost:2181
[127.0.0.1:11211-(localhost)]
[127.0.0.1:11212-(localhost)]
[127.0.0.1:11211-(localhost)]
PREFIX test       itm      11 kitm       6 litm       0 sitm       1 bitm       4
                  tsz  148536 ktsz     480 ltsz       0 stsz     528 btsz  147528 time 20160609083239

(no result from stats detail dump)

[127.0.0.1:11212-(localhost)]
PREFIX test       itm       5 kitm       2 litm       1 sitm       0 bitm       2
                  tsz   70272 ktsz     168 ltsz     408 stsz       0 btsz   69696 time 20160609083239

PREFIX test       get       2 hit       2 set       2 del       0
                  lcs       1 lis       6 lih       6 lds       0 ldh       0 lgs       3 lgh       3
                  scs       0 sis       0 sih       0 sds       0 sdh       0 sgs       0 sgh       0 ses       0 seh       0
                  bcs       2 bis    1512 bih    1512 bus       0 buh       0 bds       0 bdh       0
                              bps       0 bph       0 bms       0 bmh       0 bgs       1 bgh       1 bns       0 bnh       0
                              pfs       0 pfh       0 pgs       0 pgh       0
                  gps       0 gph       0 gas       0 sas       0

[Total]
PREFIX test       itm      16 kitm       8 litm       1 sitm       1 bitm       6
                  tsz  218808 ktsz     648 ltsz     408 stsz     528 btsz  217224

PREFIX test       get       2 hit       2 set       2 del       0
                  lcs       1 lis       6 lih       6 lds       0 ldh       0 lgs       3 lgh       3
                  scs       0 sis       0 sih       0 sds       0 sdh       0 sgs       0 sgh       0 ses       0 seh       0
                  bcs       2 bis    1512 bih    1512 bus       0 buh       0 bds       0 bdh       0
                              bps       0 bph       0 bms       0 bmh       0 bgs       1 bgh       1 bns       0 bnh       0
                              pfs       0 pfh       0 pgs       0 pgh       0
                  gps       0 gph       0 gas       0 sas       0
```

prefix name으로 `<all>`을 입력하면 모든 prefix에 대한 통계가 출력됩니다.

```
[127.0.0.1:11212-(localhost)]
PREFIX test       itm       6 kitm       2 litm       1 sitm       1 bitm       2
                  tsz   70800 ktsz     168 ltsz     408 stsz     528 btsz   69696 time 20160609083441
PREFIX arcus      itm       1 kitm       1 litm       0 sitm       0 bitm       0
                  tsz      80 ktsz      80 ltsz       0 stsz       0 btsz       0 time 20160609083444

PREFIX test       get       4 hit       4 set       4 del       0
                  lcs       2 lis      12 lih      12 lds       0 ldh       0 lgs       6 lgh       6
                  scs       1 sis       6 sih       6 sds       0 sdh       0 sgs       3 sgh       3 ses       6 seh       6
                  bcs       4 bis    3024 bih    3024 bus       0 buh       0 bds       0 bdh       0
                              bps       0 bph       0 bms       0 bmh       0 bgs       4 bgh       3 bns       0 bnh       0
                              pfs       0 pfh       0 pgs       0 pgh       0
                  gps       0 gph       0 gas       0 sas       0
PREFIX arcus      get       0 hit       0 set      45 del       0
                  lcs       0 lis       0 lih       0 lds       0 ldh       0 lgs       0 lgh       0
                  scs       0 sis       0 sih       0 sds       0 sdh       0 sgs       0 sgh       0 ses       0 seh       0
                  bcs       0 bis       0 bih       0 bus       0 buh       0 bds       0 bdh       0
                              bps       0 bph       0 bms       0 bmh       0 bgs       0 bgh       0 bns       0 bnh       0
                              pfs       0 pfh       0 pgs       0 pgh       0
                  gps       0 gph       0 gas       0 sas       0
```
