### PR TITLE
correct itoh function in test.py.

### DIFF
--- a/test.py
+++ b/test.py
@@ -190,14 +190,10 @@ assert ret.get_result() == False
 # TEST 4: btree
 #
 #####################################################################################################
+# int to hex format:"0xFFFF"
 def itoh(i):
 	h = hex(i)
-	if len(h) % 2 == 1:
-		h = '0x0%s' % h[2:].upper()
-	else:
-		h = '0x%s' % h[2:].upper()
-
-	return h
+	return '0x'+('0'*(6-len(h)))+h[2:].upper()
 	
 
 


### PR DESCRIPTION
btree 플래그 연산에 있어 "0xFFFF"같이 6자리로 되어야 연산이 됩니다.
그래서 기존의 int를 hex형식의 flag로 바꿔주는 itoh함수를 0xFFFF의 형태로 바꿀 수 있도록 변경했습니다.