### PR TITLE
Fix typo in `arcus.py`

### DIFF
--- a/arcus.py
+++ b/arcus.py
@@ -1,5 +1,5 @@
 #
-# arcus-python-client - Arcus python client drvier
+# arcus-python-client - Arcus python client driver
 # Copyright 2014 NAVER Corp.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fix `drvier` to `driver`