### PR TITLE
fix zk watcher callback in arcus_util

### DIFF
--- a/arcus_util.py
+++ b/arcus_util.py
@@ -359,6 +359,10 @@ class zookeeper:
 
 		children = []
 		for child in child_list:
+			tmp = child.split('^', 2) # remove repl info
+			if len(tmp) == 3:
+				child = tmp[2]
+
 			addr = child.split('-')[0]
 			children.append(addr)
 		


### PR DESCRIPTION
arcus_util.py의 `__callback`에서는 cache_list가 수정되었을 때 기존 노드 목록과 비교하여 변경된 노드를 계산합니다.

이 때 기존 노드는 복제 관련 정보를 제외한 ip:port 문자열을 사용하지만
새로 조회한 child에는 복제 정보까지 포함한 문자열을 서로 비교하고 있어서,
모든 노드가 created 처리되는 문제가 있습니다.

`/arcus_repl/cache_list` 조회 시 복제 정보를 제외하도록 하여 ip:port 만으로 추가/제거 여부를 판단하도록 합니다.