### PR TITLE
restore zk_delete_tree

### DIFF
--- a/arcus_util.py
+++ b/arcus_util.py
@@ -141,6 +141,13 @@ class zookeeper:
 			if self.force == False:
 				raise NoNodeError
 
+	def zk_delete_tree(self, path):
+		try:
+			self.zk.delete(path, recursive=True)
+		except NoNodeError:
+			if self.force == False:
+				raise NoNodeError
+
 	def zk_update(self, path, value):
 		try:
 			self.zk.set(path, bytes(value, 'utf-8'))


### PR DESCRIPTION
`zk_delete_tree` 함수는 cb626ad0303848b40175d10c7f718639b565304d 에서 제거되었습니다.

하지만 arcustool 같은 운영 도구에서 특정 service code를 제거할 경우
내부적으로 znode directory를 제거하기 위해 `zk_delete_tree` 함수를 호출하게 되지만,
`zk_delete_tree` 함수가 없어서 실패하게 됩니다. (없는 함수 호출 시에 실패하는 오류 발생)

따라서, `zk_delete_tree` 구현을 다시 추가해 두는 것이 필요하여 PR 보냅니다.

(cc @jhpark816)